### PR TITLE
リンクテキストが空の時はURLを貼る

### DIFF
--- a/services/renderer-go/renderer/renderer.go
+++ b/services/renderer-go/renderer/renderer.go
@@ -3,8 +3,6 @@ package renderer
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"log"
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
@@ -20,17 +18,6 @@ var markdown = goldmark.New(
 		),
 	),
 )
-
-func main() {
-	src := []byte("# link samples\n" +
-		"[normal link](https://example.com)\n" +
-		"[](https://example.com)\n")
-	var buf bytes.Buffer
-	if err := markdown.Convert(src, &buf); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("%s\n", buf.String())
-}
 
 type autoTitleLinker struct {
 }

--- a/services/renderer-go/renderer/renderer.go
+++ b/services/renderer-go/renderer/renderer.go
@@ -22,14 +22,13 @@ var markdown = goldmark.New(
 type autoTitleLinker struct {
 }
 
-func (l *autoTitleLinker) Transform(node *ast.Document, reader text.Reader, pc parser.Context) error {
-	err := ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (l *autoTitleLinker) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
+	_ = ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
 		if node, ok := node.(*ast.Link); ok && entering && node.ChildCount() == 0 {
 			node.AppendChild(node, ast.NewString([]byte(node.Destination)))
 		}
 		return ast.WalkContinue, nil
 	})
-	return err
 }
 
 // Render は受け取った文書を HTML に変換する

--- a/services/renderer-go/renderer/renderer.go
+++ b/services/renderer-go/renderer/renderer.go
@@ -35,13 +35,14 @@ func main() {
 type autoTitleLinker struct {
 }
 
-func (l *autoTitleLinker) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
-	ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+func (l *autoTitleLinker) Transform(node *ast.Document, reader text.Reader, pc parser.Context) error {
+	err := ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
 		if node, ok := node.(*ast.Link); ok && entering && node.ChildCount() == 0 {
 			node.AppendChild(node, ast.NewString([]byte(node.Destination)))
 		}
 		return ast.WalkContinue, nil
 	})
+	return err
 }
 
 // Render は受け取った文書を HTML に変換する

--- a/services/renderer-go/renderer/renderer.go
+++ b/services/renderer-go/renderer/renderer.go
@@ -3,13 +3,50 @@ package renderer
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
+
+var markdown = goldmark.New(
+	goldmark.WithParserOptions(
+		parser.WithASTTransformers(
+			util.Prioritized(&autoTitleLinker{}, 999),
+		),
+	),
+)
+
+func main() {
+	src := []byte("# link samples\n" +
+		"[normal link](https://example.com)\n" +
+		"[](https://example.com)\n")
+	var buf bytes.Buffer
+	if err := markdown.Convert(src, &buf); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", buf.String())
+}
+
+type autoTitleLinker struct {
+}
+
+func (l *autoTitleLinker) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
+	ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if node, ok := node.(*ast.Link); ok && entering && node.ChildCount() == 0 {
+			node.AppendChild(node, ast.NewString([]byte(node.Destination)))
+		}
+		return ast.WalkContinue, nil
+	})
+}
 
 // Render は受け取った文書を HTML に変換する
 func Render(ctx context.Context, src string) (string, error) {
 	var html bytes.Buffer
-	err := goldmark.Convert([]byte(src), &html)
+	err := markdown.Convert([]byte(src), &html)
 	return html.String(), err
 }

--- a/services/renderer-go/renderer/renderer_test.go
+++ b/services/renderer-go/renderer/renderer_test.go
@@ -13,6 +13,11 @@ func Test_Render(t *testing.T) {
 		expect string
 	}{
 		{
+			src: `[](https://example.com)`,
+			expect: `<p><a href="https://example.com">https://example.com</a></p>
+`,
+		},
+		{
 			src: "# hoge\n## fuga",
 			expect: `<h1>hoge</h1>
 <h2>fuga</h2>


### PR DESCRIPTION
 リンク構文の表示文字列を省略した場合に自動でURLを表示する。
例えば
``` 
[](http://example.com)
```
が
``` 
<a href="http://example.com"> http://example.com </a>
```
に変換される